### PR TITLE
ci: validate action metadata schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.3
       - name: Validate Action
-        uses: meza/action-validate-action@v1.0.4
+        uses: cardinalby/schema-validator-action@2166123eb256fa40baef7e22ab1379708425efc7 # 3.1.1
+        with:
+          file: action.yml
+          schema: https://raw.githubusercontent.com/SchemaStore/schemastore/773fe876b57bb3d35693177b626164570a6bac49/src/schemas/json/github-action.json
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4.2.2
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,9 @@ name: "Verify PR"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify PR
@@ -11,4 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.3
       - name: Validate Action
-        uses: meza/action-validate-action@v1.0.4
+        uses: cardinalby/schema-validator-action@2166123eb256fa40baef7e22ab1379708425efc7 # 3.1.1
+        with:
+          file: action.yml
+          schema: https://raw.githubusercontent.com/SchemaStore/schemastore/773fe876b57bb3d35693177b626164570a6bac49/src/schemas/json/github-action.json


### PR DESCRIPTION
## What changed

- replaced the internal `meza/action-validate-action` wrapper in PR and release workflows
- pinned `cardinalby/schema-validator-action` and the SchemaStore GitHub Action schema to immutable commits
- limited the PR verification workflow to `contents: read`
- preserved release permissions, runners, triggers, and action runtime behavior

## Why

Action metadata only needs direct schema validation. Removing the internal wrapper breaks the dependency on the validator/installer action chain and allows those repositories to be retired.

## Impact

CI-only change. Public inputs, outputs, and runtime behavior are unchanged.

## Checks

- `action-validator` v0.9.0 against `action.yml` — passed
- `git diff --check` — passed