### PR TITLE
chore: enforce minimum dependency age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
- create `pnpm-workspace.yaml` with `minimumReleaseAge: 10080`
- require dependencies to be at least seven days old before installation

## Verification
- inspected the staged diff and confirmed only `pnpm-workspace.yaml` was added
- ran `git diff --staged --check`
- did not run pnpm, scripts, tests, linters, formatters, builds, or validators as required for this metadata-only change